### PR TITLE
Some cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ SCL connected to pin 5, SDA to pin 4
 example usage:
 
 ```python
+>>>from machine import I2C, Pin
 >>>import mpu6050
->>>accelerometer = mpu6050.accel()
+>>>i2c = I2C(scl=Pin(5), sda=Pin(4))
+>>>accelerometer = mpu6050.accel(i2c)
 >>>accelerometer.get_values()
 {'GyZ': -235, 'GyY': 296, 'GyX': 16, 'Tmp': 26.64764, 'AcZ': -1552, 'AcY': -412, 'AcX': 16892}
 ```

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -2,15 +2,16 @@ import machine
 
 
 class accel():
-    def __init__(self):
-        self.iic = machine.I2C(machine.Pin(5), machine.Pin(4))
+    def __init__(self, i2c, addr=0x68):
+        self.iic = i2c
+        self.addr = addr
         self.iic.start()
-        self.iic.writeto(0x68, bytearray([107, 0]))
+        self.iic.writeto(self.addr, bytearray([107, 0]))
         self.iic.stop()
 
     def get_raw_values(self):
         self.iic.start()
-        a = self.iic.readfrom_mem(0x68, 0x3B, 14)
+        a = self.iic.readfrom_mem(self.addr, 0x3B, 14)
         self.iic.stop()
         return a
 
@@ -40,5 +41,7 @@ class accel():
         # -32768 to 32767
 
     def val_test(self):  # ONLY FOR TESTING! Also, fast reading sometimes crashes IIC
+        from time import sleep
         while 1:
             print(self.get_values())
+            sleep(0.05)


### PR DESCRIPTION
* pass in an existing i2c object which can be shared to access multiple devices
* allow a non-default i2c address because the MPU60x0 has an alternate address pin
* run the test function at 20Hz (50ms interval)